### PR TITLE
Added page titles.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 # Site settings
-title: "Anidata Website"
+title: "Anidata"
 description: "The website for the Anidata organization."
 url: "http://anidata.org"
 baseurl: ""

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,8 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="icon" type="image/png" href="/images/favicon.png" />
+        {% assign folder = page.url | split: '/'  %}
+        <title>{{ site.title}}{% if folder[1] %} - {{ folder[1] | capitalize }} {% endif %}</title>
         <!-- Stylesheets -->
         <link rel="stylesheet" href="/styles/main.css">
         <!-- Javascript files -->


### PR DESCRIPTION
The browser tabs were not displaying the title correctly since we hadn't set it.  I fixed this to not only show Anidata on each tab but also the page the person was currently visiting.