### PR TITLE
Fixed bug with footer.

### DIFF
--- a/styles/main.scss
+++ b/styles/main.scss
@@ -47,6 +47,10 @@
     border-radius: 0px;
 }
 
+body {
+  height: 100%;
+}
+
 #main-content {
   min-height: 94%;
 }


### PR DESCRIPTION
Apparently, when you set the height of an interior element without specifying the height of the outer element, the browsers render it differently.  This should solve the issue.